### PR TITLE
added httpx in requirements_versions.txt

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -28,3 +28,4 @@ torchsde==0.2.5
 safetensors==0.3.1
 httpcore<=0.15
 fastapi==0.94.0
+httpx==0.15


### PR DESCRIPTION
fixed httpx error.

tested on AMD Ryzen 5600G with 8GB RAM, and 1GB VRAM

![Screenshot (1)](https://github.com/risharde/stable-diffusion-webui-directml/assets/141318099/dd9a3df8-6417-4b32-9711-187569f1e266)
